### PR TITLE
enable CircleCI osx build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,40 @@
+version: 2
+jobs:
+  build-macos:
+    macos:
+      xcode: "9.2.0"
+    environment:
+      CIRCLE_REPOSITORY_URL: https://github.com/dpo/homebrew-openblas
+      HOMEBREW_DEVELOPER: 1
+      HOMEBREW_NO_AUTO_UPDATE: 1
+      HOMEBREW_FORCE_VENDOR_RUBY: 1
+      HOMEBREW_VERBOSE: 1
+      HOMEBREW_VERBOSE_USING_DOTS: 1
+
+    steps:
+      - run: |
+          brew --version
+          brew update
+          cd $(brew --repo)
+          if [ -e .git/shallow ]; then echo git fetch --unshallow; fi
+          git fetch origin --tags
+          git reset --hard origin/master
+          brew --env
+          brew config
+      - checkout
+      - run: |
+          git remote set-url origin $CIRCLE_REPOSITORY_URL
+          if [ -e .git/shallow ]; then echo git fetch --unshallow; fi
+          git fetch origin
+          git reset --hard origin/master
+          repo=$(brew --repo $CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME)
+          echo $repo
+          mkdir -p $repo
+          cp -a ./ $repo/
+      - run: |
+          brew test-bot --tap=dpo/openblas
+workflows:
+  version: 2
+  test-bot:
+    jobs:
+      - build-macos


### PR DESCRIPTION
This is immediately useful because TravisCI OSX builds are impossibly backlogged. It will also be useful later to ship bottles.