### PR TITLE
octave: fix spelling of --without-osmesa

### DIFF
--- a/octave.rb
+++ b/octave.rb
@@ -119,7 +119,7 @@ class Octave < Formula
       --disable-static
       --disable-docs
       --without-fltk
-      --without-OSMesa
+      --without-osmesa
       --with-hdf5-includedir=#{Formula["hdf5"].opt_include}
       --with-hdf5-libdir=#{Formula["hdf5"].opt_lib}
       --with-x=no


### PR DESCRIPTION
There's a spelling issue with the `--without-osmesa` option to Octave. It needs to be all lower case. As is, this generates an "unrecognized option" at `configure` time.

(This was a problem in the main homebrew-core octave formula until recently, too; you probably picked it up from there.)