### PR TITLE
Update Python names and fix an audit

### DIFF
--- a/numpy.rb
+++ b/numpy.rb
@@ -1,6 +1,6 @@
 class Numpy < Formula
   desc "Package for scientific computing with Python"
-  homepage "http://www.numpy.org"
+  homepage "https://www.numpy.org"
   url "https://files.pythonhosted.org/packages/c0/3a/40967d9f5675fbb097ffec170f59c2ba19fc96373e73ad47c2cae9a30aed/numpy-1.13.1.zip"
   sha256 "c9b0283776085cb2804efff73e9955ca279ba4edafd58d3ead70b61d209c4fbb"
 
@@ -16,8 +16,8 @@ class Numpy < Formula
   option "without-python", "Build without python2 support"
 
   depends_on "gcc" => :build
-  depends_on "python" => :recommended if MacOS.version <= :snow_leopard
-  depends_on "python3" => :recommended
+  depends_on "python@2" => :recommended if MacOS.version <= :snow_leopard
+  depends_on "python" => :recommended
   depends_on "openblas"
 
   resource "nose" do

--- a/scipy.rb
+++ b/scipy.rb
@@ -11,8 +11,8 @@ class Scipy < Formula
   depends_on "gcc"
   depends_on "dpo/openblas/numpy"
   depends_on "openblas"
-  depends_on "python" => :recommended if MacOS.version <= :snow_leopard
-  depends_on "python3" => :recommended
+  depends_on "python@2" => :recommended if MacOS.version <= :snow_leopard
+  depends_on "python" => :recommended
 
   cxxstdlib_check :skip
 


### PR DESCRIPTION
This PR has fixes for some audit complaints. In the case of the `python` dependencies, they're actually semantically important.

Homebrew recently renamed its Python formulae: `python` is Python 3 now, and Python 2 is `python@2`. So the dependency on `python3` is raising an audit message. And the old `depends_on "python" => :recommended if MacOS.version <= :snow_leopard` dependencies are now picking up Python 3, but based on the age of this formula and the use of `python3`, I'm pretty sure they meant to pick up Python 2.

This PR changes the Python dependencies to use the new naming scheme, which will make things consistent with other current formulae, and I think fix the dependency on Snow Leopard.

Also shortens the `hwloc@1.11` description to make `brew audit` happy.