### PR TITLE
metis4, scotch5, sundials27: rename using new <name>@X.Y convention

### DIFF
--- a/formula_renames.json
+++ b/formula_renames.json
@@ -1,0 +1,5 @@
+{
+	"metis4": "metis@4",
+	"scotch5": "scotch@5",
+	"sundials27": "sundials@2.7"
+}

--- a/metis@4.rb
+++ b/metis@4.rb
@@ -1,4 +1,4 @@
-class Metis4 < Formula
+class MetisAT4 < Formula
   desc "Serial graph partitioning and fill-reducing ordering"
   homepage "http://glaros.dtc.umn.edu/gkhome/views/metis"
   url "http://glaros.dtc.umn.edu/gkhome/fetch/sw/metis/OLD/metis-4.0.3.tar.gz"

--- a/mumps.rb
+++ b/mumps.rb
@@ -13,7 +13,7 @@ class Mumps < Formula
   depends_on "dpo/openblas/scalapack" if build.with? "mpi"
   depends_on "dpo/openblas/metis"    => :optional if build.without? "mpi"
   depends_on "dpo/openblas/parmetis" => :optional if build.with? "mpi"
-  depends_on "dpo/openblas/scotch5"  => :optional
+  depends_on "dpo/openblas/scotch@5"  => :optional
   depends_on "dpo/openblas/scotch"   => :optional
 
   resource "mumps_simple" do
@@ -39,9 +39,9 @@ class Mumps < Formula
     makefile = (build.with? "mpi") ? "Makefile.G95.PAR" : "Makefile.G95.SEQ"
     cp "Make.inc/" + makefile, "Makefile.inc"
 
-    if build.with? "scotch5"
-      make_args += ["SCOTCHDIR=#{Formula["scotch5"].opt_prefix}",
-                    "ISCOTCH=-I#{Formula["scotch5"].opt_include}"]
+    if build.with? "scotch@5"
+      make_args += ["SCOTCHDIR=#{Formula["scotch@5"].opt_prefix}",
+                    "ISCOTCH=-I#{Formula["scotch@5"].opt_include}"]
 
       if build.with? "mpi"
         scotch_libs = "LSCOTCH=-L$(SCOTCHDIR)/lib -lptesmumps -lptscotch -lptscotcherr"
@@ -134,8 +134,8 @@ class Mumps < Formula
       resource("mumps_simple").stage do
         simple_args = ["CC=mpicc", "prefix=#{prefix}", "mumps_prefix=#{prefix}",
                        "scalapack_libdir=#{Formula["scalapack"].opt_lib}"]
-        if build.with? "scotch5"
-          simple_args += ["scotch_libdir=#{Formula["scotch5"].opt_lib}",
+        if build.with? "scotch@5"
+          simple_args += ["scotch_libdir=#{Formula["scotch@5"].opt_lib}",
                           "scotch_libs=-L$(scotch_libdir) -lptesmumps -lptscotch -lptscotcherr"]
         elsif build.with? "scotch"
           simple_args += ["scotch_libdir=#{Formula["scotch"].opt_lib}",

--- a/octave.rb
+++ b/octave.rb
@@ -21,7 +21,7 @@ class Octave < Formula
     depends_on "bison" => :build
     depends_on "icoutils" => :build
     depends_on "librsvg" => :build
-    depends_on "dpo/openblas/sundials27"
+    depends_on "dpo/openblas/sundials@2.7"
   end
 
   option "with-qt", "Compile with qt-based graphical user interface"

--- a/qr_mumps.rb
+++ b/qr_mumps.rb
@@ -9,7 +9,7 @@ class QrMumps < Formula
   depends_on "gcc"
   depends_on "dpo/openblas/metis" => :recommended
   depends_on "openblas"
-  depends_on "scotch5" => :optional
+  depends_on "scotch@5" => :optional
   depends_on "dpo/openblas/starpu" => :recommended
   depends_on "pkg-config" => :build if build.with? "starpu"
 
@@ -46,11 +46,11 @@ class QrMumps < Formula
       make_args << "LMETIS=-L#{Formula["metis"].opt_lib} -lmetis"
       make_args << "IMETIS=-I#{Formula["metis"].opt_include}"
     end
-    if build.with? "scotch5"
-      libs << "-L#{Formula["scotch5"].opt_lib}" << "-lscotch" << "-lscotcherr"
+    if build.with? "scotch@5"
+      libs << "-L#{Formula["scotch@5"].opt_lib}" << "-lscotch" << "-lscotcherr"
       cfdefs << "-Dhave_scotch"
-      make_args << "LSCOTCH=-L#{Formula["scotch5"].opt_lib} -lscotch -lscotcherr"
-      make_args << "ISCOTCH=-I#{Formula["scotch5"].opt_include}"
+      make_args << "LSCOTCH=-L#{Formula["scotch@5"].opt_lib} -lscotch -lscotcherr"
+      make_args << "ISCOTCH=-I#{Formula["scotch@5"].opt_include}"
     end
     if build.with? "starpu"
       ver = Formula["starpu"].version.to_f # should be 1.2

--- a/scotch@5.rb
+++ b/scotch@5.rb
@@ -1,4 +1,4 @@
-class Scotch5 < Formula
+class ScotchAT5 < Formula
   desc "Graph and mesh partitioning, clustering, and sparse matrix ordering"
   homepage "https://gforge.inria.fr/projects/scotch"
   url "https://gforge.inria.fr/frs/download.php/28978"

--- a/sundials@2.7.rb
+++ b/sundials@2.7.rb
@@ -1,4 +1,4 @@
-class Sundials27 < Formula
+class SundialsAT27 < Formula
   desc "Nonlinear and differential/algebraic equations solver"
   homepage "https://computation.llnl.gov/casc/sundials/main.html"
   url "https://computation.llnl.gov/projects/sundials/download/sundials-2.7.0.tar.gz"

--- a/sundials@2.7.rb
+++ b/sundials@2.7.rb
@@ -4,6 +4,8 @@ class SundialsAT27 < Formula
   url "https://computation.llnl.gov/projects/sundials/download/sundials-2.7.0.tar.gz"
   sha256 "d39fcac7175d701398e4eb209f7e92a5b30a78358d4a0c0fcc23db23c11ba104"
 
+  keg_only :versioned_formula
+
   option "with-openmp", "Enable OpenMP multithreading"
   option "without-mpi", "Do not build with MPI"
 
@@ -13,8 +15,6 @@ class SundialsAT27 < Formula
   depends_on "open-mpi" if build.with? "mpi"
   depends_on "dpo/openblas/suite-sparse"
   depends_on "openblas"
-
-  conflicts_with "sundials", :because => "this is an older version"
 
   fails_with :clang if build.with? "openmp"
 


### PR DESCRIPTION
The new <formula>@X.Y naming convention for versioned formulae is well established in core Homebrew. How about using it here, too?

This PR includes a `formula_renames.json` to provide continuity for users who might already have these installed.